### PR TITLE
V22F-965 Python bb crash when calling simulator

### DIFF
--- a/SDALib-CPP/SDALib-CPP/SDASpeedDreams.cpp
+++ b/SDALib-CPP/SDALib-CPP/SDASpeedDreams.cpp
@@ -54,6 +54,7 @@ SDAData SDASpeedDreams::UpdateSimulator(const SDAData &p_data, SDAAction &p_acti
     data.Situation.cars[0]->ctrl.brakeCmd = p_action.Brake;
     data.Situation.cars[0]->ctrl.steer = p_action.Steer;
     data.Situation.cars[0]->ctrl.gear = p_action.Gear;
+    data.Situation.raceInfo.maxDammage = 0;
 
     SimCarTable[0] = CarConstructor(p_data.SimCar, data.Situation.cars[0]);
 
@@ -82,6 +83,14 @@ SDAData SDASpeedDreams::UpdateSimulator(const SDAData &p_data, SDAAction &p_acti
     SimCarTable[0].transmission.differential->outAxis[1]->I = 0;
     SimCarTable[0].transmission.differential->outAxis[1]->Tq = 0;
     SimCarTable[0].transmission.differential->outAxis[1]->spinVel = 0;
+    SimCarTable[0].trkPos.seg->next = SimCarTable[0].trkPos.seg;
+    SimCarTable[0].trkPos.seg->prev = SimCarTable[0].trkPos.seg;
+    SimCarTable[0].trkPos.seg->lside = nullptr;
+    SimCarTable[0].trkPos.seg->rside = nullptr;
+    SimCarTable[0].fuel = 0;
+
+    SimCarTable[0].carElt->pub.state = RM_CAR_STATE_SIMU_NO_MOVE;
+    data.Situation.raceInfo.state = RM_RACE_RUNNING;
 
     // update the simulator
     double elapsed = 0;
@@ -836,7 +845,7 @@ void SDASpeedDreams::ctrlCheck(tCar *car)
 
 void SDASpeedDreams::SimInstantReConfig(tCar *car)
 {
-    return; 
+    return;
 
     tCarSetupItem *setup;
 
@@ -1629,7 +1638,7 @@ tdble SDASpeedDreams::F(tWing *wing)
 
 void SDASpeedDreams::RtTrackGlobal2Local(tTrackSeg *segment, tdble X, tdble Y, tTrkLocPos *p, int type)
 {
-    int segnotfound = 1;
+    int segnotfound = 0;
     tdble x, y;
     tTrackSeg *seg = segment;
     tTrackSeg *sseg;
@@ -3211,6 +3220,7 @@ void SDASpeedDreams::RtTrackSurfaceNormalL(tTrkLocPos *p, t3Dd *norm)
 
 void SDASpeedDreams::SimCarCollideXYScene(tCar *car)
 {
+    return;
     tTrackSeg *seg = car->trkPos.seg;
     tTrkLocPos trkpos;
     int i;

--- a/SDALib-CPP/SDALib-CPP/SDASpeedDreams.cpp
+++ b/SDALib-CPP/SDALib-CPP/SDASpeedDreams.cpp
@@ -93,7 +93,6 @@ SDAData SDASpeedDreams::UpdateSimulator(const SDAData &p_data, SDAAction &p_acti
     }
 
     data.SimCar = SimCarTable[0];
-
     delete data.Situation.cars[0];
     delete[] data.Situation.cars;
     delete SimCarTable[0].engine.curve.data;

--- a/SDALib-CPP/SDALib-CPP/SDASpeedDreams.cpp
+++ b/SDALib-CPP/SDALib-CPP/SDASpeedDreams.cpp
@@ -83,14 +83,6 @@ SDAData SDASpeedDreams::UpdateSimulator(const SDAData &p_data, SDAAction &p_acti
     SimCarTable[0].transmission.differential->outAxis[1]->I = 0;
     SimCarTable[0].transmission.differential->outAxis[1]->Tq = 0;
     SimCarTable[0].transmission.differential->outAxis[1]->spinVel = 0;
-    SimCarTable[0].trkPos.seg->next = SimCarTable[0].trkPos.seg;
-    SimCarTable[0].trkPos.seg->prev = SimCarTable[0].trkPos.seg;
-    SimCarTable[0].trkPos.seg->lside = nullptr;
-    SimCarTable[0].trkPos.seg->rside = nullptr;
-    SimCarTable[0].fuel = 0;
-
-    SimCarTable[0].carElt->pub.state = RM_CAR_STATE_SIMU_NO_MOVE;
-    data.Situation.raceInfo.state = RM_RACE_RUNNING;
 
     // update the simulator
     double elapsed = 0;
@@ -845,8 +837,6 @@ void SDASpeedDreams::ctrlCheck(tCar *car)
 
 void SDASpeedDreams::SimInstantReConfig(tCar *car)
 {
-    return;
-
     tCarSetupItem *setup;
 
     if (car->ctrl->setupChangeCmd)
@@ -1638,7 +1628,7 @@ tdble SDASpeedDreams::F(tWing *wing)
 
 void SDASpeedDreams::RtTrackGlobal2Local(tTrackSeg *segment, tdble X, tdble Y, tTrkLocPos *p, int type)
 {
-    int segnotfound = 0;
+    int segnotfound = 1;
     tdble x, y;
     tTrackSeg *seg = segment;
     tTrackSeg *sseg;
@@ -3220,7 +3210,6 @@ void SDASpeedDreams::RtTrackSurfaceNormalL(tTrkLocPos *p, t3Dd *norm)
 
 void SDASpeedDreams::SimCarCollideXYScene(tCar *car)
 {
-    return;
     tTrackSeg *seg = car->trkPos.seg;
     tTrkLocPos trkpos;
     int i;

--- a/SDALib-CPP/SDALib-Python/Driver.py
+++ b/SDALib-CPP/SDALib-Python/Driver.py
@@ -19,6 +19,10 @@ class SDADriver:
     # returns the decision maker action from the current SDAData
     def UpdateAI(self, sdaData):
 
+        sdaAction = SDATypes.SDAAction(1, 1, 1, 1)
+        newSDAData = sdaData #should be a valid SDAData struct
+        simulator.update(sdaData, sdaAction, newSDAData)
+
         # find the velocity of the car
         speed = sdaData.car.pub.dynGC.vel.x * 3.6
         self.speedLimit = sdaData.car.pub.trkPos.seg.speedLimit

--- a/SDALib-CPP/SDALib-Python/Driver.py
+++ b/SDALib-CPP/SDALib-Python/Driver.py
@@ -8,7 +8,6 @@ import sys
 sys.path.append(site.getsitepackages())
 
 import SDATypes
-import simulator
 
 class SDADriver:
     speedLimit = 80
@@ -18,11 +17,6 @@ class SDADriver:
 
     # returns the decision maker action from the current SDAData
     def UpdateAI(self, sdaData):
-
-        sdaAction = SDATypes.SDAAction(1, 1, 1, 1)
-        newSDAData = sdaData #should be a valid SDAData struct
-        simulator.update(sdaData, sdaAction, newSDAData)
-
         # find the velocity of the car
         speed = sdaData.car.pub.dynGC.vel.x * 3.6
         self.speedLimit = sdaData.car.pub.trkPos.seg.speedLimit

--- a/SDALib-CPP/SDALib-Python/PythonDriver.inl
+++ b/SDALib-CPP/SDALib-Python/PythonDriver.inl
@@ -52,7 +52,7 @@ SDAAction PythonDriver<PointerManager>::UpdateAI(SDAData &p_data)
     PyObject *sdaType = m_sdaTypesConverter.GetPythonSDATypeObject(p_data);
     if (sdaType == nullptr)
     {
-        std::cout << "Not a valid SDATYpe" << std::endl;
+        std::cout << "Not a valid SDAType" << std::endl;
         return {0, 0, 0, 0};
     }
     PyObject *updateAIFuncName = PyUnicode_FromString("UpdateAI");

--- a/SDALib-CPP/SDALib-Python/PythonDriver.inl
+++ b/SDALib-CPP/SDALib-Python/PythonDriver.inl
@@ -56,7 +56,7 @@ SDAAction PythonDriver<PointerManager>::UpdateAI(SDAData &p_data)
         return {0, 0, 0, 0};
     }
     PyObject *updateAIFuncName = PyUnicode_FromString("UpdateAI");
-    PyObject *result = PyObject_CallMethodObjArgs(m_pythonDriver, updateAIFuncName, sdaType, NULL);
+    PyObject *result = PyObject_CallMethodObjArgs(m_pythonDriver, updateAIFuncName, sdaType, NULL); // Leaks 6 allocs
     SDAAction action = m_sdaTypesConverter.GetCppSDAAction(result);
 
     Py_CLEAR(sdaType);
@@ -66,7 +66,7 @@ SDAAction PythonDriver<PointerManager>::UpdateAI(SDAData &p_data)
     if (PyErr_Occurred())
     {
         PyErr_PrintEx(0); //@NOCOVERAGE
-        PyErr_Clear();  //  @NOCOVERAGE this will reset the error indicator so you can run Python code again
+        PyErr_Clear();    //@NOCOVERAGE this will reset the error indicator so you can run Python code again
     }
 
     return action;

--- a/SDALib-CPP/SDALib-Python/PythonDriver.inl
+++ b/SDALib-CPP/SDALib-Python/PythonDriver.inl
@@ -56,7 +56,7 @@ SDAAction PythonDriver<PointerManager>::UpdateAI(SDAData &p_data)
         return {0, 0, 0, 0};
     }
     PyObject *updateAIFuncName = PyUnicode_FromString("UpdateAI");
-    PyObject *result = PyObject_CallMethodObjArgs(m_pythonDriver, updateAIFuncName, sdaType, NULL); // Leaks 6 allocs
+    PyObject *result = PyObject_CallMethodObjArgs(m_pythonDriver, updateAIFuncName, sdaType, NULL);
     SDAAction action = m_sdaTypesConverter.GetCppSDAAction(result);
 
     Py_CLEAR(sdaType);

--- a/SDALib-CPP/SDALib-Python/SDATypes.py
+++ b/SDALib-CPP/SDALib-Python/SDATypes.py
@@ -110,7 +110,7 @@ class TrackSegment:
                  radiusL, arc, center, vertex1, vertex2, vertex3, vertex4, angle1, angle2, angle3, angle4, angle5,
                  angle6, angle7, sin, cos, kzl, kzw, kyl, rgtSideNormal, envIndex, height,
                  raceInfo, doVFactor, speedLimit):
-        self.trackId = id  # int
+        self.id = id  # int
         self.type = type  # int
         self.type2 = type2  # int
         self.style = style  # int
@@ -541,7 +541,7 @@ class Differential:
 class Axle:
     def __init__(self, xpos, arbSusp, heaveSusp, wheight0, force1, force2, I):
         self.xpos = xpos #float
-        self.arbSusparbSusp = arbSusp #Suspension
+        self.arbSusp = arbSusp #Suspension
         self.heaveSusp = heaveSusp #Suspension
         self.wheight0 = wheight0 #float
         self.force = [force1, force2] #float[2]

--- a/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
+++ b/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
@@ -561,6 +561,12 @@ tPublicCar SDATypesConverter::GetCppCarPublicObject(PyObject *p_publicCar)
     publicCar.posMat[3][2] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(row4Val, 2)));
     publicCar.posMat[3][3] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(row4Val, 3)));
 
+    Py_CLEAR(posMatTuple);
+    Py_CLEAR(row1Val);
+    Py_CLEAR(row2Val);
+    Py_CLEAR(row3Val);
+    Py_CLEAR(row4Val);
+
     publicCar.trkPos = GetCppTrackLocationObject(PyObject_GetAttrString(p_publicCar, "trkPos"));
     publicCar.state = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_publicCar, "state")));
 

--- a/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
+++ b/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
@@ -2932,7 +2932,7 @@ tTransmission SDATypesConverter::GetCppTransmissionSystObject(PyObject *p_transm
     transmission.gearEff[9] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(gearEffVal, 9)));
     Py_CLEAR(gearEffVal);
 
-    transmission.curI = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_transmission, "curI")));
+    transmission.curI = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_transmission, "currI")));
 
     PyObject *differentialVal = PyList_AsTuple(PyObject_GetAttrString(p_transmission, "differential"));
     transmission.differential[0] = GetCppDifferentialSystObject(PyTuple_GetItem(differentialVal, 0));
@@ -2949,10 +2949,11 @@ tTransmission SDATypesConverter::GetCppTransmissionSystObject(PyObject *p_transm
 void SDATypesConverter::SetPythonTransmissionSystObject(PyObject *p_target, PyObject *p_data)
 {
     if (p_target == nullptr || p_data == nullptr) return;
-    COPY_PYTHON_OBJECT(p_target, p_data, "curI");
+    COPY_PYTHON_OBJECT(p_target, p_data, "currI");
     COPY_PYTHON_OBJECT(p_target, p_data, "type");
     COPY_PYTHON_ARRAY(p_target, p_data, "overallRatio", 10);
     COPY_PYTHON_ARRAY(p_target, p_data, "gearI", 10);
+    COPY_PYTHON_ARRAY(p_target, p_data, "driveI", 10);
     COPY_PYTHON_ARRAY(p_target, p_data, "driveI", 10);
     COPY_PYTHON_ARRAY(p_target, p_data, "freeI", 10);
     COPY_PYTHON_ARRAY(p_target, p_data, "gearEff", 10);

--- a/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
+++ b/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
@@ -676,8 +676,7 @@ tTrkLocPos SDATypesConverter::GetCppTrackLocationObject(PyObject *p_trackLoc)
 {
     tTrkLocPos trackLocPos;
 
-    tTrackSeg trackSeg = GetCppTrackSegmentObject(PyObject_GetAttrString(p_trackLoc, "seg"));
-    trackLocPos.seg = &trackSeg;
+    trackLocPos.seg = GetCppTrackSegmentObject(PyObject_GetAttrString(p_trackLoc, "seg"));
     trackLocPos.type = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackLoc, "type")));
     trackLocPos.toStart = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackLoc, "toStart")));
     trackLocPos.toRight = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackLoc, "toRight")));
@@ -755,55 +754,55 @@ PyObject *SDATypesConverter::GetPythonTrackSegmentObject(tTrackSeg &p_trackSeg)
 /// @brief gets the Cpp track segment object of the Python object
 /// @param  p_trackSeg The Python object
 /// @return           The Cpp object
-tTrackSeg SDATypesConverter::GetCppTrackSegmentObject(PyObject *p_trackSeg)
+tTrackSeg *SDATypesConverter::GetCppTrackSegmentObject(PyObject *p_trackSeg)
 {
-    tTrackSeg segment = {};
-    segment.name = nullptr;
+    tTrackSeg *segment = new tTrackSeg;
+    segment->name = nullptr;
 
-    segment.id = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "id")));
-    segment.type = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "type")));
-    segment.type2 = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "type2")));
-    segment.style = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "style")));
-    segment.length = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "length")));
-    segment.Time = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "time")));
-    segment.width = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "width")));
-    segment.startWidth = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "startWidth")));
-    segment.endWidth = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "endWidth")));
-    segment.lgfromstart = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "lgFromStart")));
-    segment.radius = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "radius")));
-    segment.radiusr = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "radiusR")));
-    segment.radiusl = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "radiusL")));
-    segment.arc = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "arc")));
-    segment.center = GetCppTVectorObject(PyObject_GetAttrString(p_trackSeg, "center"));
+    segment->id = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "id")));
+    segment->type = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "type")));
+    segment->type2 = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "type2")));
+    segment->style = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "style")));
+    segment->length = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "length")));
+    segment->Time = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "time")));
+    segment->width = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "width")));
+    segment->startWidth = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "startWidth")));
+    segment->endWidth = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "endWidth")));
+    segment->lgfromstart = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "lgFromStart")));
+    segment->radius = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "radius")));
+    segment->radiusr = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "radiusR")));
+    segment->radiusl = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "radiusL")));
+    segment->arc = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "arc")));
+    segment->center = GetCppTVectorObject(PyObject_GetAttrString(p_trackSeg, "center"));
 
     PyObject *vertexTuple = PyList_AsTuple(PyObject_GetAttrString(p_trackSeg, "vertex"));
-    segment.vertex[0] = GetCppTVectorObject(PyTuple_GetItem(vertexTuple, 0));
-    segment.vertex[1] = GetCppTVectorObject(PyTuple_GetItem(vertexTuple, 1));
-    segment.vertex[2] = GetCppTVectorObject(PyTuple_GetItem(vertexTuple, 2));
-    segment.vertex[3] = GetCppTVectorObject(PyTuple_GetItem(vertexTuple, 3));
+    segment->vertex[0] = GetCppTVectorObject(PyTuple_GetItem(vertexTuple, 0));
+    segment->vertex[1] = GetCppTVectorObject(PyTuple_GetItem(vertexTuple, 1));
+    segment->vertex[2] = GetCppTVectorObject(PyTuple_GetItem(vertexTuple, 2));
+    segment->vertex[3] = GetCppTVectorObject(PyTuple_GetItem(vertexTuple, 3));
     Py_CLEAR(vertexTuple);
 
     PyObject *angleTuple = PyList_AsTuple(PyObject_GetAttrString(p_trackSeg, "angle"));
-    segment.angle[0] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 0)));
-    segment.angle[1] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 1)));
-    segment.angle[2] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 2)));
-    segment.angle[3] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 3)));
-    segment.angle[4] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 4)));
-    segment.angle[5] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 5)));
-    segment.angle[6] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 6)));
+    segment->angle[0] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 0)));
+    segment->angle[1] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 1)));
+    segment->angle[2] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 2)));
+    segment->angle[3] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 3)));
+    segment->angle[4] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 4)));
+    segment->angle[5] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 5)));
+    segment->angle[6] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(angleTuple, 6)));
     Py_CLEAR(angleTuple);
 
-    segment.sin = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "sin")));
-    segment.cos = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "cos")));
-    segment.Kzl = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "kzl")));
-    segment.Kzw = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "kzw")));
-    segment.Kyl = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "kyl")));
-    segment.rgtSideNormal = GetCppTVectorObject(PyObject_GetAttrString(p_trackSeg, "rgtSideNormal"));
-    segment.envIndex = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "envIndex")));
-    segment.height = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "height")));
-    segment.raceInfo = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "raceInfo")));
-    segment.DoVfactor = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "doVFactor")));
-    segment.SpeedLimit = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "speedLimit")));
+    segment->sin = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "sin")));
+    segment->cos = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "cos")));
+    segment->Kzl = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "kzl")));
+    segment->Kzw = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "kzw")));
+    segment->Kyl = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "kyl")));
+    segment->rgtSideNormal = GetCppTVectorObject(PyObject_GetAttrString(p_trackSeg, "rgtSideNormal"));
+    segment->envIndex = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "envIndex")));
+    segment->height = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "height")));
+    segment->raceInfo = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "raceInfo")));
+    segment->DoVfactor = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "doVFactor")));
+    segment->SpeedLimit = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackSeg, "speedLimit")));
 
     return segment;
 }

--- a/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
+++ b/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
@@ -535,11 +535,11 @@ tPublicCar SDATypesConverter::GetCppCarPublicObject(PyObject *p_publicCar)
     publicCar.DynGCg = GetCppDynamicPointObject(PyObject_GetAttrString(p_publicCar, "dynGCg"));
     publicCar.speed = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_publicCar, "speed")));
 
-    PyObject *p_posMatTuple = PyList_AsTuple(PyObject_GetAttrString(p_publicCar, "posMat"));
-    PyObject *row1Val = PyList_AsTuple(PyTuple_GetItem(p_posMatTuple, 0));
-    PyObject *row2Val = PyList_AsTuple(PyTuple_GetItem(p_posMatTuple, 1));
-    PyObject *row3Val = PyList_AsTuple(PyTuple_GetItem(p_posMatTuple, 2));
-    PyObject *row4Val = PyList_AsTuple(PyTuple_GetItem(p_posMatTuple, 3));
+    PyObject *posMatTuple = PyList_AsTuple(PyObject_GetAttrString(p_publicCar, "posMat"));
+    PyObject *row1Val = PyList_AsTuple(PyTuple_GetItem(posMatTuple, 0));
+    PyObject *row2Val = PyList_AsTuple(PyTuple_GetItem(posMatTuple, 1));
+    PyObject *row3Val = PyList_AsTuple(PyTuple_GetItem(posMatTuple, 2));
+    PyObject *row4Val = PyList_AsTuple(PyTuple_GetItem(posMatTuple, 3));
 
     publicCar.posMat[0][0] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(row1Val, 0)));
     publicCar.posMat[0][1] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(row1Val, 1)));

--- a/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
+++ b/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
@@ -221,6 +221,7 @@ SDAData SDATypesConverter::GetCppSDAData(PyObject *p_data)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonSDATypeObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     SetPythonCarObject(PyObject_GetAttrString(p_target, "car"), PyObject_GetAttrString(p_data, "car"));
     SetPythonSituationObject(PyObject_GetAttrString(p_target, "situation"), PyObject_GetAttrString(p_data, "situation"));
     SetPythonCarSystObject(PyObject_GetAttrString(p_target, "simCar"), PyObject_GetAttrString(p_data, "simCar"));
@@ -271,6 +272,7 @@ tCarElt SDATypesConverter::GetCppCarObject(PyObject *p_car)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCarObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     COPY_PYTHON_OBJECT(p_target, p_data, "index");
     SetPythonCarInitObject(PyObject_GetAttrString(p_target, "info"), PyObject_GetAttrString(p_data, "info"));
     SetPythonCarPublicObject(PyObject_GetAttrString(p_target, "pub"), PyObject_GetAttrString(p_data, "pub"));
@@ -376,6 +378,7 @@ tInitCar SDATypesConverter::GetCppCarInitObject(PyObject *p_initCar)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCarInitObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[16]{"name", "sName", "codename", "teamName", "carName", "category", "raceNumber",
                                   "startRank", "driverType", "networkPlayer", "skillLevel", "tank", "steerLock", "masterModel", "skinName", "skinTargets"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 16);
@@ -433,6 +436,7 @@ tWheelSpec SDATypesConverter::GetCppWheelSpecificationObject(PyObject *p_wheelSp
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonWheelSpecificationObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[5]{"rimRadius", "tireHeight", "tireWidth", "brakeDiskRadius", "wheelRadius"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 5);
 }
@@ -480,6 +484,7 @@ tVisualAttributes SDATypesConverter::GetCppVisualAttributesObject(PyObject *p_vi
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonVisualAttributesObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[2]{"exhaustNb", "exhaustPower"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 2);
 
@@ -576,6 +581,7 @@ tPublicCar SDATypesConverter::GetCppCarPublicObject(PyObject *p_publicCar)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCarPublicObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[2]{"speed", "state"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 2);
 
@@ -637,6 +643,7 @@ tDynPt SDATypesConverter::GetCppDynamicPointObject(PyObject *p_dynPt)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonDynamicPointObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     SetPythonPosDObject(PyObject_GetAttrString(p_target, "pos"), PyObject_GetAttrString(p_data, "pos"));
     SetPythonPosDObject(PyObject_GetAttrString(p_target, "vel"), PyObject_GetAttrString(p_data, "vel"));
     SetPythonPosDObject(PyObject_GetAttrString(p_target, "acc"), PyObject_GetAttrString(p_data, "acc"));
@@ -669,8 +676,8 @@ tTrkLocPos SDATypesConverter::GetCppTrackLocationObject(PyObject *p_trackLoc)
 {
     tTrkLocPos trackLocPos;
 
-    trackLocPos.seg = new tTrackSeg[1];
-    trackLocPos.seg[0] = GetCppTrackSegmentObject(PyObject_GetAttrString(p_trackLoc, "seg"));
+    tTrackSeg trackSeg = GetCppTrackSegmentObject(PyObject_GetAttrString(p_trackLoc, "seg"));
+    trackLocPos.seg = &trackSeg;
     trackLocPos.type = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackLoc, "type")));
     trackLocPos.toStart = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackLoc, "toStart")));
     trackLocPos.toRight = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_trackLoc, "toRight")));
@@ -683,6 +690,7 @@ tTrkLocPos SDATypesConverter::GetCppTrackLocationObject(PyObject *p_trackLoc)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonTrackLocationObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[5]{"type", "toStart", "toRight", "toMiddle", "toLeft"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 5);
 
@@ -803,6 +811,7 @@ tTrackSeg SDATypesConverter::GetCppTrackSegmentObject(PyObject *p_trackSeg)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonTrackSegmentObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[24]{"id", "type", "type2", "style", "length", "time", "width", "startWidth", "endWidth", "lgFromStart", "radius", "radiusR",
                                   "radiusL", "arc", "sin", "cos", "kzl", "kzw", "kyl", "envIndex", "height",
                                   "raceInfo", "doVFactor", "speedLimit"};
@@ -897,6 +906,7 @@ tCarRaceInfo SDATypesConverter::GetCppCarRaceInfoObject(PyObject *p_carRaceInfo)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCarRaceInfoObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[27]{"bestLapTime", "commitBestLapTime", "deltaBestLapTime", "curLapTime",
                                   "lastLapTime", "curTime", "topSpeed", "currentMinSpeedForLap", "laps", "bestLap", "nbPitStops", "remainingLaps", "pos",
                                   "timeBehindLeader", "lapsBehindLeader", "timeBehindPrev", "timeBeforeNext", "distRaced", "distFromStartLine",
@@ -1069,6 +1079,7 @@ tPrivCar SDATypesConverter::GetCppCarPrivObject(PyObject *p_privCar)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCarPrivObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[29]{"driverIndex", "moduleIndex", "modName", "gear", "gearNext", "fuel",
                                   "fuelConsumptionTotal", "fuelConsumptionInstant", "engineRPM", "engineRPMRedLine", "engineRPMMax",
                                   "engineRPMMaxTq", "engineRPMMaxPw", "engineMaxTq", "engineMaxPw", "gearNb",
@@ -1133,6 +1144,7 @@ tPosd SDATypesConverter::GetCppPosDObject(PyObject *p_posD)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonPosDObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[7]{"x", "y", "z", "xy", "ax", "ay", "az"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 7);
 }
@@ -1173,6 +1185,7 @@ tCollisionState SDATypesConverter::GetCppCollisionStateObject(PyObject *p_collis
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCollisionStateObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     COPY_PYTHON_OBJECT(p_target, p_data, "collisionCount");
     SetPythonVectorObject(PyObject_GetAttrString(p_target, "pos"), PyObject_GetAttrString(p_data, "pos"));
     SetPythonVectorObject(PyObject_GetAttrString(p_target, "force"), PyObject_GetAttrString(p_data, "force"));
@@ -1224,6 +1237,7 @@ t3Dd SDATypesConverter::GetCppTVectorObject(PyObject *p_vec)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonVectorObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[3]{"x", "y", "z"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 3);
 }
@@ -1321,6 +1335,7 @@ tCarCtrl SDATypesConverter::GetCppCarCtrlObject(PyObject *p_carCtrl)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCarCtrlObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[20]{"steer", "accelCmd", "brakeCmd", "clutchCmd", "brakeFrontLeftCmd", "brakeFrontRightCmd", "brakeRearLeftCmd",
                                   "brakeRearRightCmd", "wingFrontCmd", "wingRearCmd", "reserved1", "reserved2", "gear", "raceCmd", "lightCmd", "eBrakeCmd",
                                   "wingControlMode", "singleWheelBrakeMode", "switch3", "telemetryMode"};
@@ -1676,6 +1691,7 @@ tCarSetup SDATypesConverter::GetCppCarSetupObject(PyObject *p_carSetup)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCarSetupObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     COPY_PYTHON_CARSETUP_ARRAY(p_target, p_data, "wingAngle", 2);
     COPY_PYTHON_CARSETUP_ARRAY(p_target, p_data, "gearRatio", 10);
     COPY_PYTHON_ARRAY(p_target, p_data, "differentialType", 3);
@@ -1767,6 +1783,7 @@ tCarSetupItem SDATypesConverter::GetCppCarSetupItemObject(PyObject *p_carSetupIt
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCarSetupItemObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[6]{"value", "min", "max", "desiredValue", "stepSize", "changed"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 6);
 }
@@ -1809,6 +1826,7 @@ tCarPitCmd SDATypesConverter::GetCppCarPitCmdObject(PyObject *p_carPitCmd)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCarPitCmdObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[5]{"fuel", "repair", "stopType", "setupChanged", "tireChange"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 5);
 }
@@ -1851,6 +1869,7 @@ tSituation SDATypesConverter::GetCppSituationObject(PyObject *p_situation)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonSituationObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[4]{"deltaTime", "currentTime", "accelTime", "nbPlayers"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 4);
 
@@ -1903,6 +1922,7 @@ tRaceAdmInfo SDATypesConverter::GetCppRaceInfoObject(PyObject *p_raceInfo)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonRaceInfoObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[9]{"ncars", "totLaps", "extraLaps", "totTime", "state", "type", "maxDamage", "fps", "features"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 9);
 }
@@ -1986,6 +2006,7 @@ tAero SDATypesConverter::GetCppAeroObject(PyObject *p_aero)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonAeroObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[3]{"drag", "Cd", "CdBody"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 3);
     COPY_PYTHON_ARRAY(p_target, p_data, "lift", 2);
@@ -2074,6 +2095,7 @@ tWing SDATypesConverter::GetCppWingObject(PyObject *p_wing)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonWingObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[27]{"Kx", "Kz", "Kz_org", "angle", "AoAatMax", "AoAatZero", "AoAatZRad",
                                   "AoAOffset", "CliftMax", "CliftZero", "CliftAsymp",
                                   "a", "b", "c", "d", "f", "AoStall", "Stallw", "AR", "Kx1", "Kx2", "Kx3", "Kx4", "Kz1", "Kz2",
@@ -2118,6 +2140,7 @@ tDamperDef SDATypesConverter::GetCppDamperDefObject(PyObject *p_damperDef)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonDamperDefObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[5]{"C1", "b1", "v1", "C2", "b2"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 5);
 }
@@ -2150,6 +2173,7 @@ tDamper SDATypesConverter::GetCppDamperObject(PyObject *p_damper)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonDamperObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     SetPythonDamperDefObject(PyObject_GetAttrString(p_target, "bump"), PyObject_GetAttrString(p_data, "bump"));
     SetPythonDamperDefObject(PyObject_GetAttrString(p_target, "rebound"), PyObject_GetAttrString(p_data, "rebound"));
 }
@@ -2190,6 +2214,7 @@ tSpring SDATypesConverter::GetCppSpringObject(PyObject *p_spring)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonSpringObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[6]{"K", "F0", "x0", "xMax", "bellcrank", "packers"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 6);
 }
@@ -2234,6 +2259,7 @@ tSuspension SDATypesConverter::GetCppSuspensionObject(PyObject *p_suspension)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonSuspensionObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[6]{"inertance", "x", "v", "a", "force", "state"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 6);
 
@@ -2283,6 +2309,7 @@ tBrake SDATypesConverter::GetCppBrakeObject(PyObject *p_brake)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonBrakeObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[9]{"pressure", "Tq", "coeff", "I", "radius", "temp", "TCL", "ABS", "EnableABS"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 9);
 }
@@ -2317,6 +2344,7 @@ tBrakeSyst SDATypesConverter::GetCppBrakeSystObject(PyObject *p_brakeSyst)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonBrakeSystObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[3]{"rep", "coeff", "ebrake_pressure"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 3);
 }
@@ -2353,6 +2381,7 @@ tDynAxis SDATypesConverter::GetCppDynAxisSystObject(PyObject *p_dynAxis)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonDynAxisSystObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[4]{"spinVel", "Tq", "brkTq", "I"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 4);
 }
@@ -2409,6 +2438,7 @@ tDifferential SDATypesConverter::GetCppDifferentialSystObject(PyObject *p_differ
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonDifferentialSystObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[12]{"type", "ratio", "I", "efficiency", "bias", "dTqMin", "dTqMax", "dSlipMax", "dCoastSlipMax",
                                   "lockInputTq", "viscosity", "viscomax"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 12);
@@ -2459,6 +2489,7 @@ tAxle SDATypesConverter::GetCppAxleSystObject(PyObject *p_axle)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonAxleSystObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[3]{"xpos", "wheight0", "I"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 3);
 
@@ -2497,6 +2528,7 @@ tSteer SDATypesConverter::GetCppSteerSystObject(PyObject *p_steer)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonSteerSystObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[3]{"steerLock", "maxSpeed", "steer"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 3);
 }
@@ -2655,6 +2687,7 @@ tWheel SDATypesConverter::GetCppWheelSystObject(PyObject *p_wheel)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonWheelSystObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[46]{"torqueAlign", "roolRes", "rideHeight", "zRoad", "driveTq", "vt", "spinTq", "spinVel", "prespinVel", "state",
                                   "axleFz", "axleFz3rd", "sa", "sx", "steer", "cosax", "sinax", "weight0", "tireSpringRate", "radius", "mu", "I", "curI", "mfC", "mfB", "mfE",
                                   "lfMax", "lfMin", "lfK", "opLoad", "AlignTqFactor", "mass", "camber", "pressure", "Ttire", "Topt", "Tinit", "muTmult", "heatingm", "aircoolm", "speedcoolm",
@@ -2714,6 +2747,7 @@ tGearbox SDATypesConverter::GetCppGearBoxObject(PyObject *p_gearBox)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonGearBoxObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[6]{"gear", "gearMin", "gearMax", "gearNext", "shiftTime", "timeToEngage"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 6);
 }
@@ -2752,6 +2786,7 @@ tClutch SDATypesConverter::GetCppClutchObject(PyObject *p_clutch)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonClutchObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[5]{"state", "mode", "timeToRelease", "releaseTime", "transferValue"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 5);
 }
@@ -2898,7 +2933,7 @@ tTransmission SDATypesConverter::GetCppTransmissionSystObject(PyObject *p_transm
     transmission.gearEff[9] = static_cast<float>(PyFloat_AsDouble(PyTuple_GetItem(gearEffVal, 9)));
     Py_CLEAR(gearEffVal);
 
-    transmission.curI = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_transmission, "currI")));
+    transmission.curI = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_transmission, "curI")));
 
     PyObject *differentialVal = PyList_AsTuple(PyObject_GetAttrString(p_transmission, "differential"));
     transmission.differential[0] = GetCppDifferentialSystObject(PyTuple_GetItem(differentialVal, 0));
@@ -2914,7 +2949,8 @@ tTransmission SDATypesConverter::GetCppTransmissionSystObject(PyObject *p_transm
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonTransmissionSystObject(PyObject *p_target, PyObject *p_data)
 {
-    COPY_PYTHON_OBJECT(p_target, p_data, "currI");
+    if (p_target == nullptr || p_data == nullptr) return;
+    COPY_PYTHON_OBJECT(p_target, p_data, "curI");
     COPY_PYTHON_OBJECT(p_target, p_data, "type");
     COPY_PYTHON_ARRAY(p_target, p_data, "overallRatio", 10);
     COPY_PYTHON_ARRAY(p_target, p_data, "gearI", 10);
@@ -2966,6 +3002,7 @@ tEngineCurve SDATypesConverter::GetCppEngineCurveObject(PyObject *p_engineCurve)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonEngineCurveObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[6]{"maxTq", "maxPw", "rpmMaxPw", "TqAtMaxPw", "rpmMaxTq", "npPts"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 6);
 }
@@ -3030,6 +3067,7 @@ tEngine SDATypesConverter::GetCppEngineSystObject(PyObject *p_engine)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonEngineSystObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[17]{"revsLimiter", "revsMax", "tickover", "I", "rads", "Tq", "Tq_response", "I_joint", "fuelcons",
                                   "brakeCoeff", "brakeLinCoeff", "pressure", "exhaust_pressure", "exhaust_refract", "timeInLimiter", "TCL", "EnableTCL"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 17);
@@ -3221,6 +3259,7 @@ tCar SDATypesConverter::GetCppCarSystObject(PyObject *p_car)
 /// @brief Copies the PyObject to a new PyObject
 void SDATypesConverter::SetPythonCarSystObject(PyObject *p_target, PyObject *p_data)
 {
+    if (p_target == nullptr || p_data == nullptr) return;
     const char *attributeList[17]{"mass", "Minv", "tank", "fuel", "fuel_consumption", "fuel_prev", "fuel_time", "airSpeed2", "Cosz", "Sinz", "collision", "wheelbase", "wheeltrack",
                                   "blocked", "dammage", "features", "collisionAware"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 17);

--- a/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
+++ b/SDALib-CPP/SDALib-Python/SDATypesConverter.cpp
@@ -746,7 +746,7 @@ tTrackSeg SDATypesConverter::GetCppTrackSegmentObject(PyObject *p_trackSeg)
     tTrackSeg segment = {};
     segment.name = nullptr;
 
-    segment.id = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "trackId")));
+    segment.id = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "id")));
     segment.type = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "type")));
     segment.type2 = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "type2")));
     segment.style = static_cast<int>(PyLong_AsLong(PyObject_GetAttrString(p_trackSeg, "style")));
@@ -2436,7 +2436,7 @@ tAxle SDATypesConverter::GetCppAxleSystObject(PyObject *p_axle)
     tAxle axle;
 
     axle.xpos = static_cast<float>(PyFloat_AsDouble(PyObject_GetAttrString(p_axle, "xpos")));
-    axle.arbSusp = GetCppSuspensionObject(PyObject_GetAttrString(p_axle, "arbSusparbSusp"));
+    axle.arbSusp = GetCppSuspensionObject(PyObject_GetAttrString(p_axle, "arbSusp"));
     axle.heaveSusp = GetCppSuspensionObject(PyObject_GetAttrString(p_axle, "heaveSusp"));
 
     PyObject *forceVal = PyList_AsTuple(PyObject_GetAttrString(p_axle, "force"));
@@ -2456,7 +2456,7 @@ void SDATypesConverter::SetPythonAxleSystObject(PyObject *p_target, PyObject *p_
     const char *attributeList[3]{"xpos", "wheight0", "I"};
     COPY_PYTHON_OBJECT_LIST(p_target, p_data, attributeList, 3);
 
-    SetPythonSuspensionObject(PyObject_GetAttrString(p_target, "arbSusparbSusp"), PyObject_GetAttrString(p_data, "arbSusparbSusp"));
+    SetPythonSuspensionObject(PyObject_GetAttrString(p_target, "arbSusp"), PyObject_GetAttrString(p_data, "arbSusp"));
     SetPythonSuspensionObject(PyObject_GetAttrString(p_target, "heaveSusp"), PyObject_GetAttrString(p_data, "heaveSusp"));
     COPY_PYTHON_ARRAY(p_target, p_data, "force", 2);
 }

--- a/SDALib-CPP/SDALib-Python/SDATypesConverter.h
+++ b/SDALib-CPP/SDALib-Python/SDATypesConverter.h
@@ -52,7 +52,7 @@ public:
     void SetPythonTrackLocationObject(PyObject* p_target, PyObject* p_data);
 
     PyObject* GetPythonTrackSegmentObject(tTrackSeg& p_trackSeg);
-    tTrackSeg GetCppTrackSegmentObject(PyObject* p_trackSeg);
+    tTrackSeg* GetCppTrackSegmentObject(PyObject* p_trackSeg);
     void SetPythonTrackSegmentObject(PyObject* p_target, PyObject* p_data);
 
     PyObject* GetPythonCarRaceInfoObject(tCarRaceInfo& p_carRaceInfo);

--- a/SDALib-CPP/SDALib-Python/SpeedDreamsPython.cpp
+++ b/SDALib-CPP/SDALib-Python/SpeedDreamsPython.cpp
@@ -21,16 +21,23 @@ static PyObject* simulator_update(PyObject* p_self, PyObject* p_args)
     PyObject* data = PyTuple_GetItem(p_args, 0);
     PyObject* action = PyTuple_GetItem(p_args, 1);
 
-    // SDATypesConverter sdaTypesConverter = SDATypesConverter();
+    SDATypesConverter sdaTypesConverter = SDATypesConverter();
 
-    // SDAData oldData = sdaTypesConverter.GetCppSDAData(data);
-    // SDAAction oldAction = sdaTypesConverter.GetCppSDAAction(action);
+    SDAData oldData = sdaTypesConverter.GetCppSDAData(data);
+    SDAAction oldAction = sdaTypesConverter.GetCppSDAAction(action);
 
-    // SDASpeedDreams sdaSpeedDreams;
-    // SDAData newData = sdaSpeedDreams.UpdateSimulator(oldData, oldAction);
+    SDASpeedDreams sdaSpeedDreams;
+    SDAData newData = oldData; //sdaSpeedDreams.UpdateSimulator(oldData, oldAction);
 
-    // PyObject* newDataObject = sdaTypesConverter.GetPythonSDATypeObject(newData);
-    // sdaTypesConverter.SetPythonSDATypeObject(PyTuple_GetItem(p_args, 2), newDataObject);
+    PyObject* newDataObject = sdaTypesConverter.GetPythonSDATypeObject(newData);
+    sdaTypesConverter.SetPythonSDATypeObject(PyTuple_GetItem(p_args, 2), newDataObject);
+
+    delete oldData.Car.pub.trkPos.seg;
+    delete oldData.SimCar.trkPos.seg;
+    for(int i = 0; i < 4; i++)
+    {
+        delete oldData.SimCar.wheel[i].trkPos.seg;
+    }
 
     return PyLong_FromDouble(1);
 }

--- a/SDALib-CPP/SDALib-Python/SpeedDreamsPython.cpp
+++ b/SDALib-CPP/SDALib-Python/SpeedDreamsPython.cpp
@@ -12,41 +12,32 @@
 #include "SDASpeedDreams.h"
 #include "SDATypesConverter.h"
 
-
 /// @brief           Calls speed dream functions from Python
 /// @param  p_data   The data
 /// @param  p_action The action to be performed
 /// @return The updated SDAData
-static PyObject* simulator_update(PyObject *p_self, PyObject* p_args)
+static PyObject* simulator_update(PyObject* p_self, PyObject* p_args)
 {
     PyObject* data = PyTuple_GetItem(p_args, 0);
     PyObject* action = PyTuple_GetItem(p_args, 1);
 
-    SDATypesConverter sdaTypesConverter = SDATypesConverter();
+    // SDATypesConverter sdaTypesConverter = SDATypesConverter();
 
-    SDAData oldData = sdaTypesConverter.GetCppSDAData(data);
-    SDAAction oldAction = sdaTypesConverter.GetCppSDAAction(action);
+    // SDAData oldData = sdaTypesConverter.GetCppSDAData(data);
+    // SDAAction oldAction = sdaTypesConverter.GetCppSDAAction(action);
 
-    SDASpeedDreams sdaSpeedDreams;
-    SDAData newData = sdaSpeedDreams.UpdateSimulator(oldData, oldAction);
+    // SDASpeedDreams sdaSpeedDreams;
+    // SDAData newData = sdaSpeedDreams.UpdateSimulator(oldData, oldAction);
 
-    delete[] oldData.Car.pub.trkPos.seg;
-    delete[] oldData.SimCar.trkPos.seg;
-    delete[] oldData.SimCar.wheel[0].trkPos.seg;
-    delete[] oldData.SimCar.wheel[1].trkPos.seg;
-    delete[] oldData.SimCar.wheel[2].trkPos.seg;
-    delete[] oldData.SimCar.wheel[3].trkPos.seg;
-
-    PyObject* newDataObject = sdaTypesConverter.GetPythonSDATypeObject(newData);
-    sdaTypesConverter.SetPythonSDATypeObject(PyTuple_GetItem(p_args, 2), newDataObject);
+    // PyObject* newDataObject = sdaTypesConverter.GetPythonSDATypeObject(newData);
+    // sdaTypesConverter.SetPythonSDATypeObject(PyTuple_GetItem(p_args, 2), newDataObject);
 
     return PyLong_FromDouble(1);
 }
 
 static PyMethodDef simulator_methods[] = {
-    {"update", simulator_update, METH_VARARGS, "" },
-    { NULL, NULL, 0, NULL }
-};
+    {"update", simulator_update, METH_VARARGS, ""},
+    {NULL, NULL, 0, NULL}};
 
 static struct PyModuleDef simulator_module =
     {

--- a/SDALib-CPP/SDALib-Python/SpeedDreamsPython.cpp
+++ b/SDALib-CPP/SDALib-Python/SpeedDreamsPython.cpp
@@ -30,6 +30,13 @@ static PyObject* simulator_update(PyObject *p_self, PyObject* p_args)
     SDASpeedDreams sdaSpeedDreams;
     SDAData newData = sdaSpeedDreams.UpdateSimulator(oldData, oldAction);
 
+    delete[] oldData.Car.pub.trkPos.seg;
+    delete[] oldData.SimCar.trkPos.seg;
+    delete[] oldData.SimCar.wheel[0].trkPos.seg;
+    delete[] oldData.SimCar.wheel[1].trkPos.seg;
+    delete[] oldData.SimCar.wheel[2].trkPos.seg;
+    delete[] oldData.SimCar.wheel[3].trkPos.seg;
+
     PyObject* newDataObject = sdaTypesConverter.GetPythonSDATypeObject(newData);
     sdaTypesConverter.SetPythonSDATypeObject(PyTuple_GetItem(p_args, 2), newDataObject);
 

--- a/SDALib-CPP/SDALibTests/SDATypesConverterTest.cpp
+++ b/SDALib-CPP/SDALibTests/SDATypesConverterTest.cpp
@@ -287,7 +287,7 @@ void CheckTrackSegmentData(tTrackSeg& p_trackSeg, PyObject* p_trackSegObject)
 {
     PyObject* idAttr = PyUnicode_FromString("id");
     PyObject* idVal = PyObject_GetAttr(p_trackSegObject, idAttr);
-    ASSERT_TRUE(p_trackSeg.id == static_cast<int>(PyLong_AsLong(idVal)));
+    ASSERT_EQ(p_trackSeg.id, static_cast<int>(PyLong_AsLong(idVal)));
 
     PyObject* typeAttr = PyUnicode_FromString("type");
     PyObject* typeVal = PyObject_GetAttr(p_trackSegObject, typeAttr);

--- a/SDALib-CPP/SDALibTests/SDATypesConverterTest.cpp
+++ b/SDALib-CPP/SDALibTests/SDATypesConverterTest.cpp
@@ -2474,7 +2474,7 @@ TEST(PythonConverterTests, PythonDriverGetSDATypeObjectTest)
     SDATypesConverter converter = SDATypesConverter();
 
     Random random;
-    // for (int i = 0; i < TEST_COUNT; i++)
+    for (int i = 0; i < TEST_COUNT; i++)
     {
         SDAData sdaData;
         TestSegments segments = GenerateSegments();

--- a/SDALib-CPP/SDALibTests/SDATypesConverterTest.cpp
+++ b/SDALib-CPP/SDALibTests/SDATypesConverterTest.cpp
@@ -285,9 +285,9 @@ void CheckMatrixData(sgMat4& p_posMat, PyObject* p_posMatObject)
 /// @param  p_trackSeg The python track segment object
 void CheckTrackSegmentData(tTrackSeg& p_trackSeg, PyObject* p_trackSegObject)
 {
-    // PyObject* idAttr = PyUnicode_FromString("trackId");
-    // PyObject* idVal = PyObject_GetAttr(p_trackSegObject, idAttr);
-    // ASSERT_TRUE(p_trackSeg.id == static_cast<int>(PyLong_AsLong(idVal)));
+    PyObject* idAttr = PyUnicode_FromString("id");
+    PyObject* idVal = PyObject_GetAttr(p_trackSegObject, idAttr);
+    ASSERT_TRUE(p_trackSeg.id == static_cast<int>(PyLong_AsLong(idVal)));
 
     PyObject* typeAttr = PyUnicode_FromString("type");
     PyObject* typeVal = PyObject_GetAttr(p_trackSegObject, typeAttr);
@@ -1741,7 +1741,7 @@ void CheckAxleData(tAxle p_axle, PyObject* p_axleObject)
     PyObject* xposVal = PyObject_GetAttr(p_axleObject, xposAttr);
     ASSERT_EQ(p_axle.xpos, static_cast<float>(PyFloat_AsDouble(xposVal)));
 
-    PyObject* arbSuspAttr = PyUnicode_FromString("arbSusparbSusp");
+    PyObject* arbSuspAttr = PyUnicode_FromString("arbSusp");
     PyObject* arbSuspVal = PyObject_GetAttr(p_axleObject, arbSuspAttr);
     CheckSuspensionData(p_axle.arbSusp, arbSuspVal);
 
@@ -2474,7 +2474,7 @@ TEST(PythonConverterTests, PythonDriverGetSDATypeObjectTest)
     SDATypesConverter converter = SDATypesConverter();
 
     Random random;
-    for (int i = 0; i < TEST_COUNT; i++)
+    // for (int i = 0; i < TEST_COUNT; i++)
     {
         SDAData sdaData;
         TestSegments segments = GenerateSegments();


### PR DESCRIPTION
This PR is meant to fix the python blackbox crashing when `simulator.update()` is called in UpdateAI of python Driver.py.

DONE:
- @larsdekwant Fixed memory leaks from calling `simulator.update()` in the python Driver.py

TODO:
- @klieverse Fix the actual crash 